### PR TITLE
Fix typo

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 
 #include <stdbool.h>
 
-#include "audiomoth.h"
+#include "audioMoth.h"
 
 /* Firmware version and description */
 


### PR DESCRIPTION
In src/main.c, audiomoth.h instead of audioMoth.h